### PR TITLE
Fixed getAPIKey() return

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -51,7 +51,7 @@ const getAPIKey = async () => {
       placeholder: "sk-1234567890",
       validate: (input) => {
         if (input.startsWith("sk-")) {
-          return true;
+          return apiKey;
         } else {
           return convertString("API key must start with sk-");
         }


### PR DESCRIPTION
Previously once asked for the key after you entered it in and hit Enter it would just say true, because it just retuned true, when it should've returned the apiKey.